### PR TITLE
[UPDATE] Bugfix: Comic Sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/playwright-report
 
 # next.js
 /.next/

--- a/components/Calendar/YearView/index.tsx
+++ b/components/Calendar/YearView/index.tsx
@@ -4,6 +4,7 @@ import filterByMonth from "../../../helpers/filterByMonth";
 import { Dispatch, SetStateAction } from "react";
 import { Comic } from "../../../types/types";
 import { monthsType } from "../../../data/months";
+import { useState } from 'react';
 
 interface Props {
   comics: Comic[],
@@ -11,6 +12,7 @@ interface Props {
   setActiveComic: Dispatch<SetStateAction<Comic>>
 }
 const YearView = ({ comics, year, setActiveComic }:Props) => {
+  const [comicsSorted,] = useState(comicsByMonth(comics))
   const navigateToYr = () => setActiveComic(comics[0]);
 
   const navigateToMo = (mo:monthsType) => setActiveComic(filterByMonth(comics, mo)[0]);
@@ -26,7 +28,7 @@ const YearView = ({ comics, year, setActiveComic }:Props) => {
         </button>
       </div>
       <div>
-        {comicsByMonth(comics).map(([mo, comics]:[monthsType, Comic[]]) => (
+        {comicsSorted.map(([mo, comics]:[monthsType, Comic[]]) => (
           <div className="flex justify-start " key={`${year}-${mo}`}>
             <button
               className="w-12 font-bold flex-shrink-0  right-outline pt-2 hover:text-red-300 transition-all"

--- a/components/Calendar/index.tsx
+++ b/components/Calendar/index.tsx
@@ -9,7 +9,6 @@ interface Props {
 }
 const Calendar = ({ comics, setActiveComic }:Props) => {
   const [splitComics,] = useState(comicsByYear(comics));
-
   return (
     <div className="h-screen bg-[#FEFAEE] overflow-auto no-scrollbar">
       <div className="p-5 pl-16 pr-16">

--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -24,7 +24,7 @@ const Main = ({ comics }: Props) => {
       const foundComicIndex = comics.findIndex(
         (comicDir) => comicDir._id === comic._id
       );
-      if (foundComicIndex && comics[foundComicIndex + 1])
+      if (foundComicIndex < comics.length-1 && comics[foundComicIndex + 1])
         return setActiveComic(comics[foundComicIndex + 1]);
     },
   ];

--- a/helpers/comicsByMonth.ts
+++ b/helpers/comicsByMonth.ts
@@ -1,16 +1,16 @@
 import months from "../data/months";
-import {Comic} from '../types/types';
+import { Comic } from "../types/types";
 
-type MonthGroup = [string, Comic[]]
+type MonthGroup = [string, Comic[]];
 
 /**
  * @param comics Array of comics in a year
  * @returns { MonthGroup[] } sorted 2D array of comics in the year by month
-*/
-const comicsByMonth = (comics:Comic[]):MonthGroup[] => {
+ */
+const comicsByMonth = (comics: Comic[]): MonthGroup[] => {
   const map = new Map();
   comics.forEach((comic) => {
-    const [mo, day] = comic.title.split(".");
+    const [mo,,] = comic.title.split(".");
     const month = months[Number(mo) - 1];
     if (!map.has(month)) {
       map.set(month, [comic]);
@@ -18,26 +18,9 @@ const comicsByMonth = (comics:Comic[]):MonthGroup[] => {
       map.set(month, [...map.get(month), comic]);
     }
   });
-
-
-  const sortedComics:MonthGroup[] = Array.from(map)
-    .reverse()
-    .sort((prev,curr) => {
-      return months.indexOf(prev[0]) <
-          months.indexOf(curr[0])
-          ? -1
-          : 1;
-    })
-    .map((month) => {
-      const sorted = month[1].sort((prev, curr) => {
-        return Number(prev.title.split(".")[1]) <
-          Number(curr.title.split(".")[1])
-          ? -1
-          : 1;
-      });
-      return [month[0], sorted];
-    });
-  return sortedComics;
+  return Array.from(map)
+  .reverse()
+  .map((mo) => [mo[0], mo[1]]);
 };
 
 export default comicsByMonth;

--- a/helpers/comicsByMonth.ts
+++ b/helpers/comicsByMonth.ts
@@ -18,8 +18,16 @@ const comicsByMonth = (comics:Comic[]):MonthGroup[] => {
       map.set(month, [...map.get(month), comic]);
     }
   });
+
+
   const sortedComics:MonthGroup[] = Array.from(map)
     .reverse()
+    .sort((prev,curr) => {
+      return months.indexOf(prev[0]) <
+          months.indexOf(curr[0])
+          ? -1
+          : 1;
+    })
     .map((month) => {
       const sorted = month[1].sort((prev, curr) => {
         return Number(prev.title.split(".")[1]) <

--- a/helpers/comics_sorter.ts
+++ b/helpers/comics_sorter.ts
@@ -1,22 +1,62 @@
 import { Comic } from "../types/types";
 
+
+/** Formula for sorting comics */
+const singleSort = (prev:Comic,curr:Comic) => {
+  let p = (prev.title.split('.')).map((num)=>Number(num))
+
+  let pYr = p.pop()
+  p.unshift(pYr);
+
+  let c = (curr.title.split('.')).map((num)=>Number(num))
+  let cYr = c.pop()
+  c.unshift(cYr);
+
+  for (let i= 0; i<3; i++) {
+    if (p[i] < c[i]) return -1;
+    else if (p[i] > c[i]) return 1;
+
+  }
+}
+
+/** Base case for Merge Sort */
+function merge (left:any[], right:any[]):any[] {
+  let resultArray = [], leftIndex = 0, rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    if (singleSort(left[leftIndex],right[rightIndex]) < 0 ) {
+      resultArray.push(left[leftIndex]);
+      leftIndex++; // move left array cursor
+    } else {
+      resultArray.push(right[rightIndex]);
+      rightIndex++; // move right array cursor
+    }
+  }
+  return resultArray
+          .concat(left.slice(leftIndex))
+          .concat(right.slice(rightIndex));
+}
+
+/** Recursive merge sort algo */
+const mergeSort = (arr:any[]):any[] => {
+  if (arr.length <= 1) {
+    return arr;
+  }
+  const middle = Math.floor(arr.length / 2);
+  const left = arr.slice(0, middle);
+  const right = arr.slice(middle);
+  return merge(
+    mergeSort(left), mergeSort(right)
+  );
+}
+
 /**
  * @param comics Full list of comics
  * @returns Full list of comics sorted by month and year.
- */
-const comics_sorter = (comics: Comic[]) =>
-  comics.sort((prev, curr) => {
-    let prevArr = prev.title.split(".");
-    prevArr.unshift(prevArr[1]);
-    prevArr.splice(2, 1);
-    let currArr = curr.title.split(".");
-    currArr.unshift(currArr[1]);
-    currArr.splice(2, 1);
+*/
+const comics_sorter = (comics: Comic[]) =>{
 
-    for (let i = 2; i >= 0; i--) {
-      if (prevArr[i] < currArr[i]) return -1;
-      if (prevArr[i] > currArr[i]) return 1;
-    }
-});
+  return mergeSort(comics);
+
+};
 
 export default comics_sorter;


### PR DESCRIPTION
Previous implementation of sorting all fetched comics wasn't working correctly.
Adjusted to use `mergeSort` algorithm for efficiency. 
Removed previous formulas for sorting by month as full data is now sorted immediately on fetch and persists.